### PR TITLE
Fix missing prefixes

### DIFF
--- a/ontology/organs.owl
+++ b/ontology/organs.owl
@@ -7,6 +7,10 @@
      xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
      xmlns:xml="http://www.w3.org/XML/1998/namespace"
      xmlns:xsd="http://www.w3.org/2001/XMLSchema#"
+     xmlns:dc="http://purl.org/dc/elements/1.1/"
+     xmlns:vann="http://purl.org/vocab/vann/"
+     xmlns:terms="http://purl.org/dc/terms/"
+     xmlns:cc="http://creativecommons.org/ns#"
      xmlns:core="https://w3id.org/polifonia/ontology/core/0.1#"
      xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#">
     <owl:Ontology rdf:about="https://w3id.org/polifonia/ontology/organs/">


### PR DESCRIPTION
Adds missing prefixes that were not declared but used by the changes introduced in 1eedea4c8d3d73c1d91b5d6397e793e4992edd2f and prevented the ontology from being loaded correctly